### PR TITLE
Use env vars secret in deployment; update ci/cd; add readme

### DIFF
--- a/.github/workflows/cd-helm-release.yml
+++ b/.github/workflows/cd-helm-release.yml
@@ -32,8 +32,7 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add coturn https://small-hack.github.io/coturn-chart/
-          helm dep update charts/matrix
+          helm dep update charts/matrix-sliding-sync
 
       - name: Run chart-releaser
         id: helm-release

--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add coturn https://small-hack.github.io/coturn-chart
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
@@ -49,4 +48,4 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args '--set=postgresql.volumePermissions.enabled=false --set=postgresql.primary.networkPolicy.enabled=false'

--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -3,7 +3,7 @@ name: Lint and Test Chart
 on:
   pull_request:
     paths:
-      - 'charts/matrix/**'
+      - 'charts/matrix-sliding-sync/**'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
-# matrix sliding-sync helm chart
+# Matrix Sliding Sync helm chart
 
-This is a helm chart implementing [matrix-org/sliding-sync](https://github.com/matrix-org/sliding-sync/tree/main).
+<a href="https://github.com/small-hack/matrix-sliding-sync-chart/releases"><img src="https://img.shields.io/github/v/release/small-hack/matrix-sliding-sync-chart?style=plastic&labelColor=blue&color=green&logo=GitHub&logoColor=white"></a>
+
+This is a helm chart implementing [matrix-org/sliding-sync](https://github.com/matrix-org/sliding-sync/tree/main) for deployment on Kubernetes. It was originally designed for use as a subchart for [small-hack/matrix-chart](https://github.com/small-hack/matrix-chart), but it can be used stand alone as well.
+
+See the [`README.md`](https://github.com/small-hack/matrix-sliding-sync-chart/blob/main/charts/matrix/README.md) for docs auto-generated from the [`values.yaml`](https://github.com/small-hack/matrix-sliding-sync-chart/blob/main/charts/matrix/values.yaml).
+
+Read through the parameters and modify them locally before installing the chart:
+
+```bash
+# add the helm repo locally
+helm repo add matrix-sliding-sync https://small-hack.github.io/matrix-sliding-sync-chart
+
+# downloads the values.yaml locally
+helm show values matrix-sliding-sync/matrix-sliding-sync > values.yaml
+
+# install the chart
+helm install my-release-name matrix-sliding-sync/matrix-sliding-sync --values values.yaml
+```

--- a/charts/matrix-sliding-sync/Chart.yaml
+++ b/charts/matrix-sliding-sync/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/matrix-sliding-sync/Chart.yaml
+++ b/charts/matrix-sliding-sync/Chart.yaml
@@ -30,3 +30,7 @@ dependencies:
     version: 15.1.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
+
+maintainers:
+  - name: jessebot
+    url: https://github.com/jessebot

--- a/charts/matrix-sliding-sync/README.md
+++ b/charts/matrix-sliding-sync/README.md
@@ -1,6 +1,6 @@
 # matrix-sliding-sync
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.99.17](https://img.shields.io/badge/AppVersion-v0.99.17-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.99.17](https://img.shields.io/badge/AppVersion-v0.99.17-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -19,11 +19,11 @@ A Helm chart for Kubernetes
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| externalDatabase.database | string | `"matrix"` | name of the database to try and connect to |
+| externalDatabase.database | string | `"matrix-sliding-sync"` | name of the database to try and connect to |
 | externalDatabase.enabled | bool | `false` | enable using an external database *instead of* the Bitnami PostgreSQL sub-chart if externalDatabase.enabled is set to true, postgresql.enabled must be set to false |
 | externalDatabase.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
 | externalDatabase.hostname | string | `""` | hostname of db server. Can be left blank if using postgres subchart |
-| externalDatabase.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |
+| externalDatabase.password | string | `"changeme"` | password of matrix-sliding-sync postgres user - ignored using exsitingSecret |
 | externalDatabase.port | int | `5432` | which port to use to connect to your database server |
 | externalDatabase.secretKeys.adminPasswordKey | string | `"postgresPassword"` | key in existingSecret with the admin postgresql password |
 | externalDatabase.secretKeys.database | string | `"database"` | key in existingSecret with name of the database |
@@ -34,7 +34,7 @@ A Helm chart for Kubernetes
 | externalDatabase.sslkey | string | `""` | optional: tls/ssl key for postgresql connections |
 | externalDatabase.sslmode | string | `""` | sslmode to use, example: verify-full |
 | externalDatabase.sslrootcert | string | `""` | optional: tls/ssl root cert for postgresql connections |
-| externalDatabase.username | string | `"matrix"` | username of matrix postgres user |
+| externalDatabase.username | string | `"matrix-sliding-sync"` | username of matrix-sliding-sync postgres user |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/matrix-org/sliding-sync"` |  |
@@ -56,14 +56,14 @@ A Helm chart for Kubernetes
 | podSecurityContext | object | `{}` |  |
 | postgresql.enabled | bool | `true` | Whether to deploy the Bitnami Postgresql sub chart If postgresql.enabled is set to true, externalDatabase.enabled must be set to false else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false |
 | postgresql.global.postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
-| postgresql.global.postgresql.auth.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |
+| postgresql.global.postgresql.auth.password | string | `"changeme"` | password of matrix-sliding-sync postgres user - ignored using exsitingSecret |
 | postgresql.global.postgresql.auth.port | int | `5432` | which port to use to connect to your database server |
 | postgresql.global.postgresql.auth.secretKeys.adminPasswordKey | string | `"postgresPassword"` | key in existingSecret with the admin postgresql password |
 | postgresql.global.postgresql.auth.secretKeys.database | string | `"database"` | key in existingSecret with name of the database |
 | postgresql.global.postgresql.auth.secretKeys.databaseHostname | string | `"hostname"` | key in existingSecret with hostname of the database |
-| postgresql.global.postgresql.auth.secretKeys.databaseUsername | string | `"username"` | key in existingSecret with username for matrix to connect to db |
-| postgresql.global.postgresql.auth.secretKeys.userPasswordKey | string | `"password"` | key in existingSecret with password for matrix to connect to db |
-| postgresql.global.postgresql.auth.username | string | `"matrix-sliding-sync"` | username of matrix postgres user |
+| postgresql.global.postgresql.auth.secretKeys.databaseUsername | string | `"username"` | key in existingSecret with username for matrix-sliding-sync to connect to db |
+| postgresql.global.postgresql.auth.secretKeys.userPasswordKey | string | `"password"` | key in existingSecret with password for matrix-sliding-sync to connect to db |
+| postgresql.global.postgresql.auth.username | string | `"matrix-sliding-sync"` | username of matrix-sliding-sync postgres user |
 | postgresql.primary.initdb | object | `{"scriptsConfigMap":"{{ .Release.Name }}-postgresql-initdb"}` | run the scripts in templates/postgresql/initdb-configmap.yaml If using an external Postgres server, make sure to configure the database ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md |
 | postgresql.primary.persistence | object | `{"enabled":false,"size":"8Gi"}` | persistent volume claim configuration for postgresql to persist data |
 | postgresql.primary.persistence.enabled | bool | `false` | Enable PostgreSQL Primary data persistence using PVC |
@@ -85,15 +85,16 @@ A Helm chart for Kubernetes
 | serviceAccount.name | string | `""` |  |
 | syncv3.bindaddr | string | `"0.0.0.0:8008"` | SYNCV3_BINDADDR - The interface and port to listen on. (Supports unix socket: /path/to/socket) |
 | syncv3.db | string | `""` | SYNCV3_DB - Required. The postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING |
-| syncv3.log_level | string | `"info"` | SYNCV3_LOG_LEVEL - The level of verbosity for messages logged. Available values are trace, debug, info, warn, error and fatal |
-| syncv3.max_db_conn | string | `""` | SYNCV3_MAX_DB_CONN - Default: unset. Max database connections to use when communicating with postgres. Unset or 0 means no limit. |
-| syncv3.otlp_password | string | `""` | SYNCV3_OTLP_PASSWORD - Default: unset. The OTLP password for Basic auth. If unset, does not send an Authorization header. |
-| syncv3.otlp_url | string | `""` | SYNCV3_OTLP_URL - Default: unset. The OTLP HTTP URL to send spans to e.g https://localhost:4318 - if unset does not send OTLP traces. |
-| syncv3.otlp_username | string | `""` | SYNCV3_OTLP_USERNAME - Default: unset. The OTLP username for Basic auth. If unset, does not send an Authorization header. |
+| syncv3.existingSecret | string | `""` | existing kubernetes secret for syncv3 env vars listed above, ignores all above if set. |
+| syncv3.logLevel | string | `"info"` | SYNCV3_LOG_LEVEL - The level of verbosity for messages logged. Available values are trace, debug, info, warn, error and fatal |
+| syncv3.maxDbConn | string | `""` | SYNCV3_MAX_DB_CONN - Default: unset. Max database connections to use when communicating with postgres. Unset or 0 means no limit. |
+| syncv3.otlpPassword | string | `""` | SYNCV3_OTLP_PASSWORD - Default: unset. The OTLP password for Basic auth. If unset, does not send an Authorization header. |
+| syncv3.otlpUrl | string | `""` | SYNCV3_OTLP_URL - Default: unset. The OTLP HTTP URL to send spans to e.g https://localhost:4318 - if unset does not send OTLP traces. |
+| syncv3.otlpUsername | string | `""` | SYNCV3_OTLP_USERNAME - Default: unset. The OTLP username for Basic auth. If unset, does not send an Authorization header. |
 | syncv3.pprof | string | `""` | SYNCV3_PPROF - Default: unset. The bind addr for pprof debugging e.g ':6060'. If not set, does not listen. |
 | syncv3.prom | string | `""` | SYNCV3_PROM - Default: unset. The bind addr for Prometheus metrics, which will be accessible at /metrics at this address. |
 | syncv3.secret | string | `""` | SYNCV3_SECRET - Required. A secret to use to encrypt access tokens. Must remain the same for the lifetime of the database. |
-| syncv3.sentry_dsn | string | `""` | SYNCV3_SENTRY_DSN - Default: unset. The Sentry DSN to report events to e.g https://sliding-sync@sentry.example.com/123 - if unset does not send sentry events. |
+| syncv3.sentryDsn | string | `""` | SYNCV3_SENTRY_DSN - Default: unset. The Sentry DSN to report events to e.g https://sliding-sync@sentry.example.com/123 - if unset does not send sentry events. |
 | syncv3.server | string | `""` | SYNCV3_SERVER - Required. The destination homeserver to talk to (CS API HTTPS URL) e.g 'https://matrix-client.matrix.org' (Supports unix socket: /path/to/socket) |
 | syncv3.tlsCert | string | `""` | SYNCV3_TLS_CERT - Default: unset. Path to a certificate file to serve to HTTPS clients. Specifying this enables TLS on the bound address. |
 | syncv3.tlsKey | string | `""` | SYNCV3_TLS_KEY - Default: unset. Path to a key file for the certificate. Must be provided along with the certificate file. |

--- a/charts/matrix-sliding-sync/README.md
+++ b/charts/matrix-sliding-sync/README.md
@@ -4,6 +4,12 @@
 
 A Helm chart for Kubernetes
 
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jessebot |  | <https://github.com/jessebot> |
+
 ## Requirements
 
 | Repository | Name | Version |
@@ -84,13 +90,14 @@ A Helm chart for Kubernetes
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | syncv3.bindaddr | string | `"0.0.0.0:8008"` | SYNCV3_BINDADDR - The interface and port to listen on. (Supports unix socket: /path/to/socket) |
-| syncv3.db | string | `""` | SYNCV3_DB - Required. The postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING |
-| syncv3.existingSecret | string | `""` | existing kubernetes secret for syncv3 env vars listed above, ignores all above if set. |
+| syncv3.db | object | `{"dbname":"matrix-sliding-sync","existingSecret":"","host":"","password":"","sslmode":"disable","user":"matrix-sliding-sync"}` | templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING like this: user=$(whoami) dbname=syncv3 sslmode=disable host=host.docker.internal password='DATABASE_PASSWORD_HERE' |
+| syncv3.existingSecret | string | `""` | existing kubernetes secret for ALL syncv3 env vars listed below. if set, ignores all values below, everything under syncv3 including syncv3.db and syncvc.otlp. |
 | syncv3.logLevel | string | `"info"` | SYNCV3_LOG_LEVEL - The level of verbosity for messages logged. Available values are trace, debug, info, warn, error and fatal |
 | syncv3.maxDbConn | string | `""` | SYNCV3_MAX_DB_CONN - Default: unset. Max database connections to use when communicating with postgres. Unset or 0 means no limit. |
-| syncv3.otlpPassword | string | `""` | SYNCV3_OTLP_PASSWORD - Default: unset. The OTLP password for Basic auth. If unset, does not send an Authorization header. |
-| syncv3.otlpUrl | string | `""` | SYNCV3_OTLP_URL - Default: unset. The OTLP HTTP URL to send spans to e.g https://localhost:4318 - if unset does not send OTLP traces. |
-| syncv3.otlpUsername | string | `""` | SYNCV3_OTLP_USERNAME - Default: unset. The OTLP username for Basic auth. If unset, does not send an Authorization header. |
+| syncv3.otlp.existingSecret | string | `nil` |  |
+| syncv3.otlp.password | string | `""` | SYNCV3_OTLP_PASSWORD - Default: unset. The OTLP password for Basic auth. If unset, does not send an Authorization header. |
+| syncv3.otlp.url | string | `""` | SYNCV3_OTLP_URL - Default: unset. The OTLP HTTP URL to send spans to e.g https://localhost:4318 - if unset does not send OTLP traces. |
+| syncv3.otlp.username | string | `""` | SYNCV3_OTLP_USERNAME - Default: unset. The OTLP username for Basic auth. If unset, does not send an Authorization header. |
 | syncv3.pprof | string | `""` | SYNCV3_PPROF - Default: unset. The bind addr for pprof debugging e.g ':6060'. If not set, does not listen. |
 | syncv3.prom | string | `""` | SYNCV3_PROM - Default: unset. The bind addr for Prometheus metrics, which will be accessible at /metrics at this address. |
 | syncv3.secret | string | `""` | SYNCV3_SECRET - Required. A secret to use to encrypt access tokens. Must remain the same for the lifetime of the database. |

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -62,6 +62,19 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Helper function to get the postgres secret containing the database credentials
+*/}}
+{{- define "matrix-sliding-sync.postgresql.secretName" -}}
+{{- if and .Values.postgresql.enabled .Values.postgresql.global.postgresql.auth.existingSecret -}}
+{{ .Values.postgresql.global.postgresql.auth.existingSecret }}
+{{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret -}}
+{{ .Values.externalDatabase.existingSecret }}
+{{- else -}}
+{{ template "matrix-sliding-sync.fullname" . }}-db-secret
+{{- end }}
+{{- end }}
+
+{{/*
 templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING like this: user=$(whoami) dbname=syncv3 sslmode=disable host=host.docker.internal password='DATABASE_PASSWORD_HERE'
 */}}
 {{- define "matrix-sliding-sync.dbConnString" -}}

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -73,3 +73,4 @@ templates out SYNCV3_DB which is a postgres connection string: https://www.postg
 {{- printf "user=%s dbname=%s sslmode=%s host=%s" .Values.syncv3.db.user .Values.syncv3.db.dbname .Values.syncv3.db.sslmode .Values.syncv3.db.host }}
 {{- end }}
 {{- end }}
+{{- end }}

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING like this: user=$(whoami) dbname=syncv3 sslmode=disable host=host.docker.internal password='DATABASE_PASSWORD_HERE'
+*/}}
+{{- if not .Values.syncv3.existingSecret  }}
+{{- define "matrix-sliding-sync.dbConnString" -}}
+{{- if .Values.syncv3.db.password (eq .Values.syncv3.db.sslmode "disable") }}
+{{- printf "user=%s dbname=%s sslmode=%s host=%s password=%s" .Values.syncv3.db.user .Values.syncv3.db.dbname .Values.syncv3.db.sslmode .Values.syncv3.db.host .Values.syncv3.db.password }}
+{{- end }}
+{{- if not eq .Values.syncv3.db.sslmode "disable" }}
+{{- printf "user=%s dbname=%s sslmode=%s host=%s" .Values.syncv3.db.user .Values.syncv3.db.dbname .Values.syncv3.db.sslmode .Values.syncv3.db.host }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -62,6 +62,15 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Helper function to get postgres instance name
+*/}}
+{{- define "postgresql.name" -}}
+{{- if .Values.postgresql.enabled -}}
+{{ include "matrix-sliding-sync.fullname" . }}-postgresql
+{{- end }}
+{{- end }}
+
+{{/*
 Helper function to get the postgres secret containing the database credentials
 */}}
 {{- define "matrix-sliding-sync.postgresql.secretName" -}}

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -64,12 +64,11 @@ Create the name of the service account to use
 {{/*
 templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING like this: user=$(whoami) dbname=syncv3 sslmode=disable host=host.docker.internal password='DATABASE_PASSWORD_HERE'
 */}}
-{{- if not .Values.syncv3.existingSecret  }}
 {{- define "matrix-sliding-sync.dbConnString" -}}
-{{- if .Values.syncv3.db.password (eq .Values.syncv3.db.sslmode "disable") }}
+{{- if and .Values.postgresql.enabled (not .Values.syncv3.existingSecret) }}
+{{- if .Values.syncv3.db.password }}
 {{- printf "user=%s dbname=%s sslmode=%s host=%s password=%s" .Values.syncv3.db.user .Values.syncv3.db.dbname .Values.syncv3.db.sslmode .Values.syncv3.db.host .Values.syncv3.db.password }}
-{{- end }}
-{{- if not eq .Values.syncv3.db.sslmode "disable" }}
+{{- else -}}
 {{- printf "user=%s dbname=%s sslmode=%s host=%s" .Values.syncv3.db.user .Values.syncv3.db.dbname .Values.syncv3.db.sslmode .Values.syncv3.db.host }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/deployment.yaml
+++ b/charts/matrix-sliding-sync/templates/deployment.yaml
@@ -50,7 +50,13 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          env:
+          envFrom:
+            - secretRef:
+          {{- if .Values.syncv3.existingSecret }}
+                name: {{ .Values.syncv3.existingSecret }}
+          {{- else }}
+                name: {{ include "matrix-sliding-sync.fullname" . }}-env
+          {{- end }}
 
       {{- with .Values.volumes }}
       volumes:

--- a/charts/matrix-sliding-sync/templates/deployment.yaml
+++ b/charts/matrix-sliding-sync/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "matrix.postgresql.secretName" . }}
+                  name: {{ include "matrix-sliding-sync.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseUsername }}
             - name: DATABASE_HOSTNAME
               {{- if not .Values.postgresql.global.postgresql.auth.existingSecret }}
@@ -46,7 +46,7 @@ spec:
               {{ else }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "matrix.postgresql.secretName" . }}
+                  name: {{ include "matrix-sliding-sync.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseHostname }}
               {{- end }}
             {{- if .Values.postgresql.sslmode }}

--- a/charts/matrix-sliding-sync/templates/deployment.yaml
+++ b/charts/matrix-sliding-sync/templates/deployment.yaml
@@ -30,6 +30,40 @@ spec:
       serviceAccountName: {{ include "matrix-sliding-sync.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: postgresql-isready
+          image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrix.postgresql.secretName" . }}
+                  key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseUsername }}
+            - name: DATABASE_HOSTNAME
+              {{- if not .Values.postgresql.global.postgresql.auth.existingSecret }}
+              value: {{ template "postgresql.v1.primary.fullname" .Subcharts.postgresql }}
+              {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrix.postgresql.secretName" . }}
+                  key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseHostname }}
+              {{- end }}
+            {{- if .Values.postgresql.sslmode }}
+            - name: PGSSLMODE
+              value: {{ .Values.postgresql.sslmode }}
+            - name: PGSSLCERT
+              value: {{ .Values.postgresql.sslcert }}
+            - name: PGSSLKEY
+              value: {{ .Values.postgresql.sslkey }}
+            - name: PGSSLROOTCERT
+              value: {{ .Values.postgresql.sslrootcert }}
+            {{- end }}
+          command:
+            - "sh"
+            - "-c"
+            - "until pg_isready -h $DATABASE_HOSTNAME -U $POSTGRES_USER; do sleep 2; done"
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/matrix-sliding-sync/templates/initdb-configmap.yaml
+++ b/charts/matrix-sliding-sync/templates/initdb-configmap.yaml
@@ -8,11 +8,6 @@ metadata:
 data:
   matrix.sql: |
     CREATE DATABASE matrix ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
-    GRANT ALL PRIVILEGES ON DATABASE matrix TO {{ .Values.postgresql.global.postgresql.auth.username }};
+    GRANT ALL PRIVILEGES ON DATABASE matrix-sliding-sync TO {{ .Values.postgresql.global.postgresql.auth.username }};
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.postgresql.global.postgresql.auth.username }};
-  {{- if .Values.bridges.irc.enabled }}
-  {{/* Scripts are run in alphabetical order */}}
-  zzz_irc.sql: |
-    CREATE DATABASE {{ .Values.bridges.irc.database }} ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
-  {{- end }}
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/initdb-configmap.yaml
+++ b/charts/matrix-sliding-sync/templates/initdb-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "matrix-sliding-sync.fullname" . }}-postgresql-initdb
+  labels:
+  {{ include "matrix-sliding-sync.labels" . | nindent 4}}
+data:
+  matrix.sql: |
+    CREATE DATABASE matrix ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
+    GRANT ALL PRIVILEGES ON DATABASE matrix TO {{ .Values.postgresql.global.postgresql.auth.username }};
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.postgresql.global.postgresql.auth.username }};
+  {{- if .Values.bridges.irc.enabled }}
+  {{/* Scripts are run in alphabetical order */}}
+  zzz_irc.sql: |
+    CREATE DATABASE {{ .Values.bridges.irc.database }} ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
+  {{- end }}
+{{- end }}

--- a/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
+++ b/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
@@ -5,14 +5,14 @@ kind: Secret
 metadata:
   name: {{ include "matrix-sliding-sync.fullname" . }}-env
 data:
+  {{- if .Values.syncv3.secret }}
+  SYNCV3_SECRET: {{ .Values.syncv3.secret | b64enc | quote }}
+  {{- else }}
+  SYNCV3_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
   SYNCV3_SERVER: {{ .Values.syncv3.server | b64enc | quote }}
   {{- if not .Values.syncv3.db.existingSecret }}
   SYNCV3_DB: {{ include "matrix-sliding-sync.dbConnString" . | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.syncv3.secret }}
-  SYNCV3_SECRET: {{ .Values.syncv3.secret | b64enc | quote }}
-  {{- else -}}
-  SYNCV3_SECRET: {{ randAlpha 32 | b64enc | quote }}
   {{- end }}
   SYNCV3_BINDADDR: {{ .Values.syncv3.bindaddr | b64enc | quote }}
   {{ if .Values.syncv3.tlsCert }}

--- a/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
+++ b/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
@@ -6,17 +6,39 @@ metadata:
   name: {{ include "matrix-sliding-sync.fullname" . }}-env
 data:
   SYNCV3_SERVER: {{ .Values.syncv3.server | b64enc | quote }}
-  SYNCV3_DB: {{ .Values.syncv3.db | b64enc | quote }}
+  {{- if not .Values.syncv3.db.existingSecret }}
+  SYNCV3_DB: {{ include "matrix-sliding-sync.dbConnString" . | b64enc | quote }}
+  {{- end }}
   SYNCV3_SECRET: {{ .Values.syncv3.secret | b64enc | quote }}
   SYNCV3_BINDADDR: {{ .Values.syncv3.bindaddr | b64enc | quote }}
+  {{ if .Values.syncv3.tlsCert }}
   SYNCV3_TLS_CERT: {{ .Values.syncv3.tlsCert | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.syncv3.tlsKey }}
   SYNCV3_TLS_KEY: {{ .Values.syncv3.tlsKey | b64enc | quote }}
+  {{- end }}
+  {{ if not .Values.syncv3.pprof }}
   SYNCV3_PPROF: {{ .Values.syncv3.pprof | b64enc | quote }}
+  {{- end }}
+  {{ if not .Values.syncv3.prom }}
   SYNCV3_PROM: {{ .Values.syncv3.prom | b64enc | quote }}
-  SYNCV3_OTLP_URL: {{ .Values.syncv3.otlpUrl | b64enc | quote }}
-  SYNCV3_OTLP_USERNAME: {{ .Values.syncv3.otlpUsername | b64enc | quote }}
-  SYNCV3_OTLP_PASSWORD: {{ .Values.syncv3.otlpPassword | b64enc | quote }}
+  {{- end }}
+  {{ if not .Values.syncv3.otlp.existingSecret }}
+  {{ if .Values.syncv3.otlp.url }}
+  SYNCV3_OTLP_URL: {{ .Values.syncv3.otlp.url | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.syncv3.otlp.username }}
+  SYNCV3_OTLP_USERNAME: {{ .Values.syncv3.otlp.username | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.syncv3.otlp.password }}
+  SYNCV3_OTLP_PASSWORD: {{ .Values.syncv3.otlp.password | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{ if .Values.syncv3.sentryDsn }}
   SYNCV3_SENTRY_DSN: {{ .Values.syncv3.sentryDsn | b64enc | quote }}
+  {{- end }}
   SYNCV3_LOG_LEVEL: {{ .Values.syncv3.logLevel | b64enc | quote }}
+  {{ if .Values.syncv3.maxDbConn }}
   SYNCV3_MAX_DB_CONN: {{ .Values.syncv3.maxDbConn | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
+++ b/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
@@ -9,7 +9,11 @@ data:
   {{- if not .Values.syncv3.db.existingSecret }}
   SYNCV3_DB: {{ include "matrix-sliding-sync.dbConnString" . | b64enc | quote }}
   {{- end }}
+  {{- if .Values.syncv3.secret }}
   SYNCV3_SECRET: {{ .Values.syncv3.secret | b64enc | quote }}
+  {{- else -}}
+  SYNCV3_SECRET: {{ randAlpha 32 | b64enc | quote }}
+  {{- end }}
   SYNCV3_BINDADDR: {{ .Values.syncv3.bindaddr | b64enc | quote }}
   {{ if .Values.syncv3.tlsCert }}
   SYNCV3_TLS_CERT: {{ .Values.syncv3.tlsCert | b64enc | quote }}

--- a/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
+++ b/charts/matrix-sliding-sync/templates/matrix-sliding-sync-env-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: sliding-sync-env
+  name: {{ include "matrix-sliding-sync.fullname" . }}-env
 data:
   SYNCV3_SERVER: {{ .Values.syncv3.server | b64enc | quote }}
   SYNCV3_DB: {{ .Values.syncv3.db | b64enc | quote }}
@@ -19,5 +19,4 @@ data:
   SYNCV3_SENTRY_DSN: {{ .Values.syncv3.sentryDsn | b64enc | quote }}
   SYNCV3_LOG_LEVEL: {{ .Values.syncv3.logLevel | b64enc | quote }}
   SYNCV3_MAX_DB_CONN: {{ .Values.syncv3.maxDbConn | b64enc | quote }}
-
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/network-policy.yaml
+++ b/charts/matrix-sliding-sync/templates/network-policy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.networkPolicies.enabled .Values.postgresql.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "matrix-sliding-sync.fullname" . }}-synapse-postgresql
+  labels:
+{{ include "matrix-sliding-sync.labels" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "postgresql.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "matrix-sliding-sync.name" . }}-synapse
+          app.kubernetes.io/instance: {{ .Release.Name }}
+    ports:
+      - port: tcp-postgresql
+        protocol: TCP
+{{- end }}

--- a/charts/matrix-sliding-sync/values.yaml
+++ b/charts/matrix-sliding-sync/values.yaml
@@ -113,6 +113,8 @@ postgresql:
   # If postgresql.enabled is set to true, externalDatabase.enabled must be set to false
   # else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false
   enabled: true
+  persistence:
+    enabled: false
   volumePermissions:
     # -- Enable init container that changes the owner and group of the PVC
     enabled: true
@@ -146,13 +148,6 @@ postgresql:
 
   # primary database node config
   primary:
-    # -- persistent volume claim configuration for postgresql to persist data
-    persistence:
-      # -- Enable PostgreSQL Primary data persistence using PVC
-      enabled: false
-      # -- size of postgresql volume claim
-      size: 8Gi
-
     # -- run the scripts in templates/postgresql/initdb-configmap.yaml
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md

--- a/charts/matrix-sliding-sync/values.yaml
+++ b/charts/matrix-sliding-sync/values.yaml
@@ -210,10 +210,20 @@ externalDatabase:
     adminPasswordKey: postgresPassword
 
 syncv3:
+  # -- existing kubernetes secret for ALL syncv3 env vars listed below. if set, ignores all values below, everything under syncv3 including syncv3.db and syncvc.otlp.
+  existingSecret: ""
   # -- SYNCV3_SERVER - Required. The destination homeserver to talk to (CS API HTTPS URL) e.g 'https://matrix-client.matrix.org' (Supports unix socket: /path/to/socket)
   server: ""
-  # -- SYNCV3_DB - Required. The postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-  db: ""
+
+  # -- templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING like this: user=$(whoami) dbname=syncv3 sslmode=disable host=host.docker.internal password='DATABASE_PASSWORD_HERE'
+  db:
+    host: ""
+    dbname: matrix-sliding-sync
+    sslmode: disable
+    user: matrix-sliding-sync
+    password: ""
+    existingSecret: ""
+
   # -- SYNCV3_SECRET - Required. A secret to use to encrypt access tokens. Must remain the same for the lifetime of the database.
   secret: ""
   # -- SYNCV3_BINDADDR - The interface and port to listen on. (Supports unix socket: /path/to/socket)
@@ -226,17 +236,19 @@ syncv3:
   pprof: ""
   # -- SYNCV3_PROM - Default: unset. The bind addr for Prometheus metrics, which will be accessible at /metrics at this address.
   prom: ""
-  # -- SYNCV3_OTLP_URL - Default: unset. The OTLP HTTP URL to send spans to e.g https://localhost:4318 - if unset does not send OTLP traces.
-  otlpUrl: ""
-  # -- SYNCV3_OTLP_USERNAME - Default: unset. The OTLP username for Basic auth. If unset, does not send an Authorization header.
-  otlpUsername: ""
-  # -- SYNCV3_OTLP_PASSWORD - Default: unset. The OTLP password for Basic auth. If unset, does not send an Authorization header.
-  otlpPassword: ""
+
+  otlp:
+    # -- SYNCV3_OTLP_URL - Default: unset. The OTLP HTTP URL to send spans to e.g https://localhost:4318 - if unset does not send OTLP traces.
+    url: ""
+    # -- SYNCV3_OTLP_USERNAME - Default: unset. The OTLP username for Basic auth. If unset, does not send an Authorization header.
+    username: ""
+    # -- SYNCV3_OTLP_PASSWORD - Default: unset. The OTLP password for Basic auth. If unset, does not send an Authorization header.
+    password: ""
+    existingSecret:
+
   # -- SYNCV3_SENTRY_DSN - Default: unset. The Sentry DSN to report events to e.g https://sliding-sync@sentry.example.com/123 - if unset does not send sentry events.
   sentryDsn: ""
   # -- SYNCV3_LOG_LEVEL - The level of verbosity for messages logged. Available values are trace, debug, info, warn, error and fatal
   logLevel: "info"
   # -- SYNCV3_MAX_DB_CONN - Default: unset. Max database connections to use when communicating with postgres. Unset or 0 means no limit.
   maxDbConn: ""
-  # -- existing kubernetes secret for syncv3 env vars listed above, ignores all above if set.
-  existingSecret: ""

--- a/charts/matrix-sliding-sync/values.yaml
+++ b/charts/matrix-sliding-sync/values.yaml
@@ -247,3 +247,8 @@ syncv3:
   logLevel: "info"
   # -- SYNCV3_MAX_DB_CONN - Default: unset. Max database connections to use when communicating with postgres. Unset or 0 means no limit.
   maxDbConn: ""
+
+
+networkPolicies:
+  # -- whether to enable kubernetes network policies or not
+  enabled: true


### PR DESCRIPTION
# Description

helps address https://github.com/small-hack/matrix-chart/issues/556

## Changes

- Actually use the secret we create as an environment variables for the deployment
- Change database name and usernames everywhere from matrix copypaste
- change default secret name to `{{ include "matrix-sliding-sync.fullname" . }}-env`
- Add root level README.md
- update ci/cd to point at matrix-sliding-sync-chart instead of matrix, and remove coturn
- update postgresql helpers templates and add networking policy

### Outstanding tasks

- [ ] auto generate secret if not provided
- [ ] fix issue where db connection string isn't templating correctly
- [ ] update postgres parameter to match [matrix chart in ci](https://github.com/small-hack/matrix-chart/blob/1703212cd4135811690ffb29593dbf9234c9af1c/.github/workflows/ci-helm-lint-test.yml#L53) ref: https://github.com/small-hack/matrix-chart/pull/532