### PR TITLE
try to make syncv3.server and syncv3.db work...

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ helm install my-release-name matrix-sliding-sync/matrix-sliding-sync --values va
 
 ## Status
 
-Not yet functional. Tests still not passing. If you know why, please submit PR.
+Kinda working. Submit PRs or Issues if something specific isn't working

--- a/charts/matrix-sliding-sync/Chart.yaml
+++ b/charts/matrix-sliding-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: matrix-sliding-sync
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying matrix sliding sync on Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/matrix-sliding-sync/README.md
+++ b/charts/matrix-sliding-sync/README.md
@@ -1,8 +1,8 @@
 # matrix-sliding-sync
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.99.17](https://img.shields.io/badge/AppVersion-v0.99.17-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.99.17](https://img.shields.io/badge/AppVersion-v0.99.17-informational?style=flat-square)
 
-A Helm chart for Kubernetes
+A Helm chart for deploying matrix sliding sync on Kubernetes
 
 ## Maintainers
 
@@ -90,8 +90,10 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
-| service.type | string | `"ClusterIP"` |  |
+| service.annotations | object | `{}` | annotations for your service |
+| service.port | int | `80` | Port of service |
+| service.targetPort | int | `8008` | targetPort of service. should be the same as port for syncv3.bindaddr |
+| service.type | string | `"ClusterIP"` | type of service |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -167,10 +167,10 @@ templates out SYNCV3_DB which is a postgres connection string: https://www.postg
 */}}
 {{- define "matrix-sliding-sync.dbConnString" -}}
 {{- if not .Values.syncv3.existingSecret }}
-{{- if or (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
-{{- printf "\"user=$PGUSER dbname=$PGDATABASE sslmode=disable host=$PGHOST password=$PGPASSWORD\"" }}
+{{- if or .Values.postgresql.enabled (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
+{{- printf "user=${PGUSER} dbname=${PGDATABASE} sslmode=${PGSSLMODE} host=${PGHOST} password=${PGPASSWORD}" }}
 {{- else -}}
-{{- printf "\"user=$PGUSER dbname=$PGDATABASE sslmode=$PGSSLMODE host=$PGHOST\"" }}
+{{- printf "user=${PGUSER} dbname=${PGDATABASE} sslmode=${PGSSLMODE} host=${PGHOST}" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -164,28 +164,13 @@ Helper function to get postgres ssl mode
 
 {{/*
 templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-{{- define "matrix-sliding-sync.dbConnString" -}}
-{{- if not .Values.syncv3.existingSecret }}
-{{- if or .Values.postgresql.enabled (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
-{{- printf "user=${PGUSER} dbname=${PGDATABASE} sslmode=${PGSSLMODE} host=${PGHOST} password=${PGPASSWORD}" }}
-{{- else -}}
-{{- printf "user=${PGUSER} dbname=${PGDATABASE} sslmode=${PGSSLMODE} host=${PGHOST}" }}
-{{- end }}
-{{- end }}
-{{- end }}
-*/}}
-
-{{/*
-templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-fmt.Sprintf("%s (%s)", version, GitCommit)
-os.Getenv(EnvDB)
 */}}
 {{- define "matrix-sliding-sync.dbConnString" -}}
 {{- if not .Values.syncv3.existingSecret }}
-{{- if or .Values.postgresql.enabled (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
-{{- printf 'fmt.Sprintf("user=%s dbname=%s sslmode=disable host=%s password=%s", os.Getenv("PGUSER"), os.Getenv("PGDATABASE"), os.Getenv("PGHOST"), os.Getenv("PGPASSWORD"))' }}
+{{- if or .Values.postgresql.enabled }}
+{{- printf "user=%s dbname=%s sslmode=disable host=%s password=%s" .Values.postgresql.global.postgresql.auth.username .Values.postgresql.global.postgresql.auth.database (include "matrix-sliding-sync.postgresql.hostname" .) .Values.postgresql.global.postgresql.auth.password }}
 {{- else -}}
-{{- printf 'fmt.Sprintf("user=%s dbname=%s sslmode=%s host=%s password=%s", os.Getenv("PGUSER"), os.Getenv("PGDATABASE"), os.Getenv("PGSSLMODE"), os.Getenv("PGHOST"), os.Getenv("PGPASSWORD"))' }}
+{{- printf "user=%s dbname=%s sslmode=%s sslmode=%s host=%s" .Values.externalDatabase.username .Values.externalDatabase.database .Values.externalDatabase.sslmode .Values.externalDatabase.hostname .Values.externalDatabase.password }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/_helpers.tpl
+++ b/charts/matrix-sliding-sync/templates/_helpers.tpl
@@ -164,13 +164,28 @@ Helper function to get postgres ssl mode
 
 {{/*
 templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-*/}}
 {{- define "matrix-sliding-sync.dbConnString" -}}
 {{- if not .Values.syncv3.existingSecret }}
 {{- if or .Values.postgresql.enabled (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
 {{- printf "user=${PGUSER} dbname=${PGDATABASE} sslmode=${PGSSLMODE} host=${PGHOST} password=${PGPASSWORD}" }}
 {{- else -}}
 {{- printf "user=${PGUSER} dbname=${PGDATABASE} sslmode=${PGSSLMODE} host=${PGHOST}" }}
+{{- end }}
+{{- end }}
+{{- end }}
+*/}}
+
+{{/*
+templates out SYNCV3_DB which is a postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+fmt.Sprintf("%s (%s)", version, GitCommit)
+os.Getenv(EnvDB)
+*/}}
+{{- define "matrix-sliding-sync.dbConnString" -}}
+{{- if not .Values.syncv3.existingSecret }}
+{{- if or .Values.postgresql.enabled (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
+{{- printf 'fmt.Sprintf("user=%s dbname=%s sslmode=disable host=%s password=%s", os.Getenv("PGUSER"), os.Getenv("PGDATABASE"), os.Getenv("PGHOST"), os.Getenv("PGPASSWORD"))' }}
+{{- else -}}
+{{- printf 'fmt.Sprintf("user=%s dbname=%s sslmode=%s host=%s password=%s", os.Getenv("PGUSER"), os.Getenv("PGDATABASE"), os.Getenv("PGSSLMODE"), os.Getenv("PGHOST"), os.Getenv("PGPASSWORD"))' }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-sliding-sync/templates/deployment.yaml
+++ b/charts/matrix-sliding-sync/templates/deployment.yaml
@@ -102,14 +102,6 @@ spec:
             {{- if or .Values.postgresql.sslmode .Values.externalDatabase.sslmode }}
             {{- include "matrix-sliding-sync.postgresql.sslEnvVars" . | nindent 12 }}
             {{- end }}
-            {{- if not .Values.syncv3.existingSecret }}
-            - name: SYNCV3_DB
-              {{- if or (not .Values.externalDatabase.sslmode) (not eq .Values.externalDatabase.sslmode "disable") }}
-              value: "user=$PGUSER dbname=$PGDATABASE sslmode=disable host=$PGHOST password=$PGPASSWORD"
-              {{- else -}}
-              value: "user=$PGUSER dbname=$PGDATABASE sslmode=$PGSSLMODE host=$PGHOST"
-              {{- end }}
-            {{- end }}
           envFrom:
             - secretRef:
           {{- if .Values.syncv3.existingSecret }}

--- a/charts/matrix-sliding-sync/templates/deployment.yaml
+++ b/charts/matrix-sliding-sync/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
             {{- if or .Values.postgresql.sslmode .Values.externalDatabase.sslmode }}
             {{- include "matrix-sliding-sync.postgresql.sslEnvVars" . | nindent 12 }}
             {{- end }}
+            {{- if not .Values.syncv3.existingSecret }}
+            - name: SYNCV3_DB
+              value: {{ include "matrix-sliding-sync.dbConnString" . }}
+            {{- end }}
           envFrom:
             - secretRef:
           {{- if .Values.syncv3.existingSecret }}


### PR DESCRIPTION
# changes
- We now template out the `SYNCV3_DB` variable if the user doesn't pass in an existing secret.
- update chart description
- add `service.targetPort` and `service.annotations` to readme docs

## Failed attempts
To keep track of what we tried and still got a failure result when testing different ways to templates the `SYNCV3_DB` env var:

- try removing syncv3 db conn string all together to see if it syncv3 picks up PG env var automatically - results in err message saying `SYNCV3_DB` is required
- try changing db env vars to be wrapped with `${}` instead of just prefixing with `$` in syncv3 db conn string - both `host=$PGHOST` and `host=${PGHOST}` result in `panic: dial tcp: lookup ${PGHOST}: no such host`
- try using go to get the env vars with
  ```go
  fmt.Sprintf("user=%s dbname=%s sslmode=disable host=%s password=%s", os.Getenv("PGUSER"), os.Getenv("PGDATABASE"), os.Getenv("PGHOST"), os.Getenv("PGPASSWORD"))
  ```
  but it does not even template

# quick links
for reference while doing dev work:

- https://github.com/matrix-org/sliding-sync?tab=readme-ov-file#running
- https://github.com/matrix-org/sliding-sync/blob/main/docs/Landing.md
- https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
- https://www.postgresql.org/docs/current/libpq-envars.html