### PR TITLE
add new renovate.json parameters to automatically catch helmv3 sub-chart updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,31 @@
     ],
     "packageRules": [
       {
+        "description": "Fix subchart archives for helm chart",
+        "matchManagers": ["helmv3"],
+        "postUpdateOptions": ["helmUpdateSubChartArchives"]
+      },
+      {
+        "description": "Fix version in Chart.yaml after helmv3 dep patch updates",
+        "matchUpdateTypes": ["patch"],
+        "matchManagers": ["helmv3"],
+        "bumpVersion": "patch"
+      },
+      {
+        "description": "Fix version in Chart.yaml after helmv3 dep minor updates",
+        "matchUpdateTypes": ["minor"],
+        "matchManagers": ["helmv3"],
+        "bumpVersion": "minor"
+      },
+      {
+        "description": "Fix version in Chart.yaml after helmv3 dep major updates",
+        "matchUpdateTypes": ["major"],
+        "matchManagers": ["helmv3"],
+        "bumpVersion": "major"
+      },
+      {
         "description": "Bump helm chart versions by a patch when updating values files. Digests, pins, rollbacks, replacements and pinDigest updates are deliberately ignored since in our use case, these need a manual decision about the version bump for the chart. This can be removed when https://github.com/renovatebot/renovate/issues/8231 is implemented and enabled.",
-        "matchManagers": ["helm-values", "helmv3", "regex", "helm-requirements"],
+        "matchManagers": ["helm-values", "regex"],
         "postUpgradeTasks": {
           "commands": [
             "bash scripts/bump-chart-version.sh '{{{updateType}}}'"


### PR DESCRIPTION
This will now update the archive, and bump chart version for sub-chart updates. It doesn't work for appVersion though.